### PR TITLE
Potential fix for code scanning alert no. 2: SQL query built from user-controlled sources

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -13,13 +13,13 @@ def index():
 
     if name:
         cursor.execute(
-            "SELECT * FROM books WHERE name LIKE '%" + name + "%'"
+            "SELECT * FROM books WHERE name LIKE %s", ('%' + name + '%',)
         )
         books = [Book(*row) for row in cursor]
 
     elif author:
         cursor.execute(
-            "SELECT * FROM books WHERE author LIKE '%" + author + "%'"
+            "SELECT * FROM books WHERE author LIKE %s", ('%' + author + '%',)
         )
         books = [Book(*row) for row in cursor]
 


### PR DESCRIPTION
Potential fix for [https://github.com/prodevlife/demo-python/security/code-scanning/2](https://github.com/prodevlife/demo-python/security/code-scanning/2)

The single best way to fix this issue is to use parameterized queries rather than interpolating user-input directly into the SQL statement. For queries involving the `LIKE` operator with wildcards, you still use parameterization, but you include the wildcards in the value that is passed as a parameter, not directly interpolated into the statement. 

Specifically, in the block for handling an `author` query (lines 21-24), replace:

```python
cursor.execute("SELECT * FROM books WHERE author LIKE '%" + author + "%'")
```

with:

```python
cursor.execute("SELECT * FROM books WHERE author LIKE %s", ('%' + author + '%',))
```
(or the correct placeholder syntax for your SQL library; many use `%s`, but some use `?` for positional parameters. Assume `%s` as context seems to match that.)

Similarly, update the block for `name` on lines 15-18 to also use a parameterized query, so both paths are safe.

No new methods are needed, and no new imports are required—the project is already using the `cursor` object and a recognizable interface similar to Python's DB-API.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
